### PR TITLE
Fix package.json conf

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vite-fast/shared",
+  "version": "1.0.0",
+  "description": "Shared types and utilities for ViteFast",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "lint": "eslint src --ext .ts",
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.0.4",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.1",
+    "@typescript-eslint/parser": "^6.13.1"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,31 @@
+// Export all types
+export * from './types.js';
+
+// Utility functions
+export const formatTimestamp = (date: Date = new Date()): string => {
+  return date.toISOString();
+};
+
+export const createApiResponse = <T>(
+  data: T,
+  message?: string,
+  success: boolean = true
+): import('./types.js').ApiResponse<T> => {
+  return {
+    data,
+    message,
+    success,
+    timestamp: formatTimestamp(),
+  };
+};
+
+export const createApiError = (
+  message: string,
+  success: boolean = false
+): import('./types.js').ApiResponse => {
+  return {
+    message,
+    success,
+    timestamp: formatTimestamp(),
+  };
+};

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,43 @@
+// Common API types
+export interface ApiResponse<T = any> {
+  data?: T;
+  message?: string;
+  success: boolean;
+  timestamp: string;
+}
+
+// Health check types
+export interface HealthResponse {
+  status: string;
+  timestamp: string;
+}
+
+// Hello endpoint types
+export interface HelloResponse {
+  message: string;
+  timestamp?: string;
+}
+
+// User types (for future use)
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// AI Agent types (for future use)
+export interface AgentMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  timestamp: string;
+}
+
+export interface AgentConversation {
+  id: string;
+  messages: AgentMessage[];
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
This pull request introduces a new shared package, `@vite-fast/shared`, to provide common types and utility functions for the ViteFast project. The package is set up with TypeScript, linting, and testing support, and defines a set of reusable API and domain types along with utility functions for consistent API responses.

**Shared package setup and configuration:**

* Added `packages/shared/package.json` to define the new package, including scripts for building, testing, linting, and cleaning, as well as necessary development dependencies.
* Added `packages/shared/tsconfig.json` to configure TypeScript compilation with strict type checking, declaration file generation, and modern module settings.

**Types and utilities:**

* Created `packages/shared/src/types.ts` to define common API response types, health check types, user types, and agent (AI) conversation types for use across multiple services.
* Implemented `packages/shared/src/index.ts` to export all types and provide utility functions for formatting timestamps and generating standardized API responses and errors.